### PR TITLE
Update schedule conversation button to use Cal.com link

### DIFF
--- a/src/components/SimpleContact.tsx
+++ b/src/components/SimpleContact.tsx
@@ -79,7 +79,7 @@ const SimpleContact = () => {
 
               <div className="space-y-3">
                 <Button className="w-full" asChild>
-                  <a href="mailto:jmaroon@mail.wlu.edu?subject=PM Opportunity Discussion">Schedule a Conversation</a>
+                  <a href="https://cal.com/jackson-maroon">Schedule a Conversation</a>
                 </Button>
                 <Button variant="outline" className="w-full" asChild>
                   <a href="mailto:jmaroon@mail.wlu.edu?subject=Resume Request">Request Full Resume</a>


### PR DESCRIPTION
## Summary
- update the "Schedule a Conversation" button in `SimpleContact` to open the new Cal.com scheduling page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c94b93548c8322afceb8f8be87d13c